### PR TITLE
Set Console/type 1 if there are arguments to parse

### DIFF
--- a/raven-cli/src/main.rs
+++ b/raven-cli/src/main.rs
@@ -54,6 +54,8 @@ fn main() -> Result<()> {
     let data = vm.reset(&rom);
     dev.reset(data);
 
+    dev.init_args(&mut vm, &args.args);
+
     // Run the reset vector
     let start = std::time::Instant::now();
     vm.run(&mut dev, 0x100);

--- a/raven-gui/src/native.rs
+++ b/raven-gui/src/native.rs
@@ -64,6 +64,8 @@ pub fn run() -> Result<()> {
 
     let _audio = audio_setup(dev.audio_streams());
 
+    dev.init_args(&mut vm, &args.args);
+
     // Run the reset vector
     let start = std::time::Instant::now();
     vm.run(&mut dev, 0x100);

--- a/raven-varvara/src/console.rs
+++ b/raven-varvara/src/console.rs
@@ -87,6 +87,16 @@ impl Console {
         // Nothing to do here; data is pre-populated in `vm.dev` memory
     }
 
+    /// Sets the appropriate type value if there are arguments to be parsed
+    ///
+    /// This should be called before running the reset vector
+    pub fn set_has_args(&mut self, vm: &mut Uxn, has_args: bool) {
+        if has_args {
+            let p = vm.dev_mut::<ConsolePorts>();
+            p.type_ = 1;
+        }
+    }
+
     /// Sets the current character type
     ///
     /// This should be called before sending a console event

--- a/raven-varvara/src/lib.rs
+++ b/raven-varvara/src/lib.rs
@@ -214,6 +214,14 @@ impl Varvara {
         self.process_event(vm, e);
     }
 
+    /// Sets initial value for Console/type based on the presense of arguments
+    ///
+    /// This should be called before running the reset vector
+    pub fn init_args(&mut self, vm: &mut Uxn, args: &[String]) {
+        self.console.set_has_args(vm, !args.is_empty());
+    }
+
+
     /// Returns the current output state of the system
     ///
     /// This is not idempotent; the output is taken from various accumulators


### PR DESCRIPTION
The [Varvara spec](https://wiki.xxiivv.com/site/varvara.html#console) states:
> The Console/type port holds one of 5 known types: no-queue(0), stdin(1), argument(2), argument-spacer(3), argument-end(4). **During the reset vector, a program should be able to query the type port and get a null byte when there is no arguments to be expected, a 1 when arguments are present.**

My [svitlyna](https://github.com/gardenappl/svitlyna) program relies on this (technically I might be able to re-write the console handling portion of it but I thought it'd be better to bring this emulator up to spec).

I can happily say that with this fix, svitlyna runs almost 50% faster than with uxn11, and that's on AMD64, meaning this is running without optimized assembly. I'm really impressed!