### PR TITLE
Fix screen resizing after initial launch

### DIFF
--- a/raven-gui/src/native.rs
+++ b/raven-gui/src/native.rs
@@ -73,6 +73,7 @@ pub fn run() -> Result<()> {
     dev.send_args(&mut vm, &args.args).check()?;
 
     let (width, height) = dev.output(&vm).size;
+    info!("creating window with size {:?}", (width, height));
     let options = eframe::NativeOptions {
         window_builder: Some(Box::new(move |v| {
             v.with_inner_size(egui::Vec2::new(width as f32, height as f32))

--- a/raven-varvara/src/lib.rs
+++ b/raven-varvara/src/lib.rs
@@ -193,11 +193,6 @@ impl Varvara {
         self.already_warned.fill(false);
     }
 
-    /// Returns the current screen size
-    pub fn screen_size(&self) -> (u16, u16) {
-        self.screen.size()
-    }
-
     /// Checks whether the SHIFT key is currently down
     fn warn_missing(&mut self, t: u8) {
         if !self.already_warned[usize::from(t >> 4)] {


### PR DESCRIPTION
My program, [svitlyna](https://github.com/gardenappl/svitlyna), resizes its screen to fit the image that it's displaying - the resizing happens after the reset vector because the program relies on `Console/vector` to get the image data.

This emulator has code for handling this scenario but it didn't seem to get triggered for whatever reason, so I re-wrote it slightly, and now it works.

----

The other issue is that, for whatever reason, the resizing doesn't always work on Wayland. I tried updating the `egui` dependency to include [this fix](https://github.com/emilk/egui/pull/4211), but it didn't seem to work either. However, the new versions require you to specify build features for Wayland and/or X11, and I was able to fix it by adding the `x11` feature but not the `wayland` feature. But I don't think that's a good solution, so I'm not submitting it.

I could try to investigate it further but I am a complete beginner in Rust, in fact these two PRs are my very first lines of Rust code.