### PR TITLE
Small cleanup

### DIFF
--- a/raven-cli/src/main.rs
+++ b/raven-cli/src/main.rs
@@ -53,7 +53,6 @@ fn main() -> Result<()> {
     let mut dev = Varvara::new();
     let data = vm.reset(&rom);
     dev.reset(data);
-
     dev.init_args(&mut vm, &args.args);
 
     // Run the reset vector

--- a/raven-gui/src/native.rs
+++ b/raven-gui/src/native.rs
@@ -61,10 +61,9 @@ pub fn run() -> Result<()> {
     let mut dev = Varvara::new();
     let extra = vm.reset(&rom);
     dev.reset(extra);
+    dev.init_args(&mut vm, &args.args);
 
     let _audio = audio_setup(dev.audio_streams());
-
-    dev.init_args(&mut vm, &args.args);
 
     // Run the reset vector
     let start = std::time::Instant::now();
@@ -75,7 +74,7 @@ pub fn run() -> Result<()> {
     dev.send_args(&mut vm, &args.args).check()?;
 
     let (width, height) = dev.output(&vm).size;
-    info!("creating window with size {:?}", (width, height));
+    info!("creating window with size ({width}, {height})");
     let options = eframe::NativeOptions {
         window_builder: Some(Box::new(move |v| {
             v.with_inner_size(egui::Vec2::new(width as f32, height as f32))

--- a/raven-varvara/src/lib.rs
+++ b/raven-varvara/src/lib.rs
@@ -209,13 +209,12 @@ impl Varvara {
         self.process_event(vm, e);
     }
 
-    /// Sets initial value for Console/type based on the presense of arguments
+    /// Sets initial value for `Console/type` based on the presense of arguments
     ///
     /// This should be called before running the reset vector
     pub fn init_args(&mut self, vm: &mut Uxn, args: &[String]) {
         self.console.set_has_args(vm, !args.is_empty());
     }
-
 
     /// Returns the current output state of the system
     ///


### PR DESCRIPTION
@gardenappl Would you mind testing `svitlyna` with these small cleanups?

For some reason, I can't build it locally:
```console
$  uxnasm svitlyna.tal out.rom
Hexadecimal invalid: add32 in @part-get-median, svitlyna.tal:1230.
```
(using `Uxnasm - Uxntal Assembler, 15 Jan 2025.`)

The only logical change is not clearing the window size to `(0, 0)` when loading a ROM; if the window size happens to be correct, then we don't need to resize it!