### PR TITLE
Make -- optional before ROM arguments

### DIFF
--- a/raven-gui/src/native.rs
+++ b/raven-gui/src/native.rs
@@ -28,7 +28,7 @@ struct Args {
     native: bool,
 
     /// Arguments to pass into the VM
-    #[arg(last = true)]
+    #[arg(trailing_var_arg = true)]
     args: Vec<String>,
 }
 


### PR DESCRIPTION
This change removes the mandatory `--` before arguments to be passed _into_ the ROM itself.

The new help text is as follows:
```
Usage: raven-gui [OPTIONS] <ROM> [ARGS]...

Arguments:
  <ROM>      ROM to load and execute
  [ARGS]...  Arguments to pass into the VM

Options:
      --scale <SCALE>  Scale factor for the window
      --native         Use the native assembly Uxn implementation
  -h, --help           Print help
  -V, --version        Print version
```

(inspired by #20, dunno if it will fix that issue on Windows)